### PR TITLE
add parens around print statements to become python3-compatible

### DIFF
--- a/pyradex/read_radex.py
+++ b/pyradex/read_radex.py
@@ -11,7 +11,7 @@ def read_radex(file,flow,fupp,bw=0.01,debug=False):
     linenum = 0
     line = file.readline()
     linenum+=1
-    if debug: print line
+    if debug: print (line)
     if line == '':
         return 0
     words = line.split()
@@ -44,7 +44,7 @@ def read_radex(file,flow,fupp,bw=0.01,debug=False):
         freq = tryfloat(words[4])
     while  not(freq*(1-bw) < fupp < freq*(1+bw)):
         line = file.readline(); linenum+=1
-        if debug: print freq,flow,line
+        if debug: print (freq,flow,line)
         words = line.split()
         if words[1] == '--':
             freq = tryfloat(words[4])


### PR DESCRIPTION
Hi Adam! don't know if you're taking pull requests, but this very very small change helped me use pyradex in python3.