### PR TITLE
datapath.setter Failing

### DIFF
--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -596,7 +596,10 @@ class Radex(RadiativeTransferApproximator):
 
     @property
     def molpath(self):
-        return b"".join(self.radex.impex.molfile).strip()
+        try:
+            return b"".join(self.radex.impex.molfile).strip()
+        except TypeError:
+            return self.radex.impex.molfile.tostring().strip()
 
     @molpath.setter
     def molpath(self, molfile):
@@ -919,7 +922,7 @@ class Radex(RadiativeTransferApproximator):
     @property
     def quantum_number(self):
         return np.array([(b"".join(x)).strip() for x in
-                         grouper(self.radex.quant.qnum.T.ravel().tolist(),6)])
+                         grouper(self.radex.quant.qnum.T.ravel().tolist(),6,fillvalue=b'')])
 
     @property
     def upperlevelnumber(self):

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -655,7 +655,8 @@ class Radex(RadiativeTransferApproximator):
         except IndexError:
             # in python3, this might just work, where the above doesn't?
             # (this works if RADAT is an S120)
-            self.radex.setup.radat = radat
+            # the added space is because the right and left side must have *exactly* the same size
+            self.radex.setup.radat = radat + " " * (self.radex.setup.radat.dtype.itemsize - len(radat))
 
 
     @property

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -613,7 +613,7 @@ class Radex(RadiativeTransferApproximator):
         try:
             self.radex.impex.molfile[:len(molfile)] = molfile
         except IndexError:
-            self.radex.impex.molfile = molfile + " " * (self.radex.impex.molfile.dtype.itemsize - len(logfile))
+            self.radex.impex.molfile = molfile + " " * (self.radex.impex.molfile.dtype.itemsize - len(molfile))
 
     @property
     def outfile(self):
@@ -631,7 +631,7 @@ class Radex(RadiativeTransferApproximator):
         try:
             self.radex.impex.outfile[:len(outfile)] = outfile
         except IndexError:
-            self.radex.impex.outfile = outfile + " " * (self.radex.impex.outfile.dtype.itemsize - len(logfile))
+            self.radex.impex.outfile = outfile + " " * (self.radex.impex.outfile.dtype.itemsize - len(outfile))
 
     @property
     def logfile(self):

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -635,7 +635,12 @@ class Radex(RadiativeTransferApproximator):
 
     @property
     def datapath(self):
-        return os.path.expanduser(b"".join(self.radex.setup.radat).strip()).decode('utf-8')
+        try:
+            return os.path.expanduser(b"".join(self.radex.setup.radat).strip()).decode('utf-8')
+        except TypeError:
+            # occurs if radat is S120 instead of array of S1
+            return os.path.expanduser((self.radex.setup.radat.tostring().decode('utf-8').strip()))
+            
 
     @datapath.setter
     def datapath(self, radat):

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -603,11 +603,17 @@ class Radex(RadiativeTransferApproximator):
         if "~" in molfile:
             molfile = os.path.expanduser(molfile)
         if PYVERSION == 3:
-            self.radex.impex.molfile[:] = np.bytes_([""]*len(self.radex.impex.molfile))
+            try:
+                self.radex.impex.molfile[:] = np.bytes_([""]*len(self.radex.impex.molfile))
+            except TypeError as ex:
+                self.radex.impex.molfile = " " * self.radex.impex.molfile.dtype.itemsize
         else:
             self.radex.impex.molfile[:] = ""
         utils.verify_collisionratefile(molfile)
-        self.radex.impex.molfile[:len(molfile)] = molfile
+        try:
+            self.radex.impex.molfile[:len(molfile)] = molfile
+        except IndexError:
+            self.radex.impex.molfile = molfile + " " * (self.radex.impex.molfile.dtype.itemsize - len(logfile))
 
     @property
     def outfile(self):
@@ -616,10 +622,16 @@ class Radex(RadiativeTransferApproximator):
     @outfile.setter
     def outfile(self, outfile):
         if PYVERSION == 3:
-            self.radex.impex.outfile[:] = np.bytes_([""]*len(self.radex.impex.outfile))
+            try:
+                self.radex.impex.outfile[:] = np.bytes_([""]*len(self.radex.impex.outfile))
+            except TypeError as ex:
+                self.radex.impex.outfile = " " * self.radex.impex.outfile.dtype.itemsize
         else:
             self.radex.impex.outfile[:] = ""
-        self.radex.impex.outfile[:len(outfile)] = outfile
+        try:
+            self.radex.impex.outfile[:len(outfile)] = outfile
+        except IndexError:
+            self.radex.impex.outfile = outfile + " " * (self.radex.impex.outfile.dtype.itemsize - len(logfile))
 
     @property
     def logfile(self):
@@ -628,10 +640,16 @@ class Radex(RadiativeTransferApproximator):
     @logfile.setter
     def logfile(self, logfile):
         if PYVERSION == 3:
-            self.radex.setup.logfile[:] = np.bytes_([""]*len(self.radex.setup.logfile))
+            try:
+                self.radex.setup.logfile[:] = np.bytes_([""]*len(self.radex.setup.logfile))
+            except TypeError as ex:
+                self.radex.setup.logfile = " " * self.radex.setup.logfile.dtype.itemsize
         else:
             self.radex.setup.logfile[:] = ""
-        self.radex.setup.logfile[:len(logfile)] = logfile
+        try:
+            self.radex.setup.logfile[:len(logfile)] = logfile
+        except IndexError:
+            self.radex.setup.logfile = logfile + " " * (self.radex.setup.logfile.dtype.itemsize - len(logfile))
 
     @property
     def datapath(self):

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -641,12 +641,21 @@ class Radex(RadiativeTransferApproximator):
     def datapath(self, radat):
         # self.radex data path not needed if molecule given as full path
         if PYVERSION == 3:
-            self.radex.setup.radat[:] = np.bytes_([""] * len(self.radex.setup.radat))
+            try:
+                self.radex.setup.radat[:] = np.bytes_([""] * len(self.radex.setup.radat))
+            except TypeError as ex:
+                # now radat gets treated as a single S120 instead of an array of S1s
+                self.radex.setup.radat = " " * self.radex.setup.radat.dtype.itemsize
         else:
             self.radex.setup.radat[:] = ""
         # there is dangerous magic here: radat needs to be interpreted as an array,
         # but you can't make it an array of characters easily...
-        self.radex.setup.radat[:len(radat)] = radat
+        try:
+            self.radex.setup.radat[:len(radat)] = radat
+        except IndexError:
+            # in python3, this might just work, where the above doesn't?
+            # (this works if RADAT is an S120)
+            self.radex.setup.radat = radat
 
 
     @property


### PR DESCRIPTION
I have tried installing this following the guide and when I call pyradex.Radex() I get the following error:

```python
/usr/local/anaconda/lib/python2.7/site-packages/pyradex/base_class.pyc in species(self, species)
    125         self._species = species
    126         try:
--> 127             self.molpath = os.path.join(self.datapath,species+'.dat')
    128         except IOError:
    129             log.warn("Did not find data file for species {0} "

/usr/local/anaconda/lib/python2.7/site-packages/pyradex/core.pyc in datapath(self)
    636     @property
    637     def datapath(self):
--> 638         return os.path.expanduser(b"".join(self.radex.setup.radat).strip()).decode('utf-8')
    639 
    640     @datapath.setter

TypeError: can only join an iterable
```
I tried to track down the error and it seems that radex.setup.radat is empty. I've tried with and without setting the RADEX_DATAPATH to the right files but get the same complaint.

I'm using:
$ python -c "import sys, astropy, numpy; print(sys.version); print(numpy.__version__,astropy.__version__)"
2.7.13 |Anaconda 2.3.0 (x86_64)| (default, Dec 20 2016, 23:05:08) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)]
('1.14.2', u'2.0.4')

$ gfortran --version
GNU Fortran (GCC) 4.8.5