### PR TITLE
Bugfix: H2+(anything) collision rates failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,26 +25,22 @@ matrix:
         #  env: SETUP_CMD='build_sphinx -w'
 
         # Try Astropy development version
-        - python: 2.7
+        - python: 3.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
         #- python: 3.3
         #  env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
-        - python: 2.7
+        - python: 3.7
           env: SETUP_CMD='test'
         #- python: 3.3
         #  env: SETUP_CMD='test'
         #- python: 3.4
         #  env: SETUP_CMD='test'
 
-        # Try older numpy versions
+        # Try older python versions
         - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+          env: SETUP_CMD='test'
 
 before_install:
 

--- a/install_radex.py
+++ b/install_radex.py
@@ -101,13 +101,19 @@ def patch_radex():
         lines = f.readlines()
 
     with open('Radex/src/readdata.f','w') as f:
-        for line in lines:
-            if 'density(3) = density(1)/(1.d0+1.d0/opr)' in line:
+        # comment out the block dealing with ortho/para ratio: let python
+        # handle that
+        for ii,line in enumerate(lines):
+            if ii <= 225 or ii > 235:
                 f.write(line)
-                f.write('c        For conservation of total density, set n(H2) = 0\n')
-                f.write('         density(1) = 0.0\n')
             else:
-                f.write(line)
+                f.write("c"+line[1:])
+            #if 'density(3) = density(1)/(1.d0+1.d0/opr)' in line:
+            #    f.write(line)
+            #    f.write('c        For conservation of total density, set n(H2) = 0\n')
+            #    f.write('         density(1) = 0.0\n')
+            #else:
+            #    f.write(line)
 
 
 
@@ -224,7 +230,7 @@ def radex_inc_method(datapath, method=1):
         lines = [L.replace('/Users/floris/Radex/moldat/',datapath)
                  if 'radat' in L else L
                  for L in f.readlines()]
-    
+
     radlines = []
     for line in lines:
         if ('parameter (method' in line):
@@ -235,4 +241,3 @@ def radex_inc_method(datapath, method=1):
 
     with open(fn,'w') as f:
         f.writelines(radlines)
-

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -131,7 +131,7 @@ def write_input(temperature=10, column=1e12, collider_densities={'H2':1},
             collider_densities.pop(k)
 
     infile.write('%s\n' % len(collider_densities))
-    for name,dens in collider_densities.iteritems():
+    for name,dens in collider_densities.items():
         infile.write('%s\n' % name)
         infile.write(str(dens)+'\n')
     infile.write(str(tbg)+'\n')

--- a/pyradex/core.py
+++ b/pyradex/core.py
@@ -364,6 +364,8 @@ class Radex(RadiativeTransferApproximator):
         if abundance:
             self.abundance = abundance
 
+        self._validate_colliders()
+
         # This has to happen here, because the colliders are read in at
         # this point and rates interpolated
         self.temperature = temperature

--- a/pyradex/tests/test_radex.py
+++ b/pyradex/tests/test_radex.py
@@ -159,6 +159,19 @@ def test_thermal_opr():
     rdx.temperature = 50
     assert rdx.density['oH2'].value == 1e4
 
+def test_h2_and_eminus():
+    """
+    regression test: readdata.f fails unless it is patched when two colliders
+    are specified, one of them is H2, and the collider file specifies H2 (not
+    oH2+pH2).  This problem is caused by the assumption that >1 collider implies
+    oH2+pH2, which is hard-coded into readdata.f and is incorrect.
+    """
+    rdx = Radex(species='hcn', collider_densities={'H2':1e4, 'e': 1e2},
+                column_per_bin=1e14, deltav=1.0, temperature=30,
+                tbackground=2.73)
+    result_table = rdx()
+
+
 def test_mod_params():
 
     RR = Radex(datapath='examples/', species='co', column=1e15,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import glob
 if any((x in sys.argv for x in ('develop','bdist'))):
     # use setuptools for develop, but nothing else
     from setuptools import setup
-    Command = object
+    from distutils.core import Command
 else:
     from distutils.core import setup, Command
 


### PR DESCRIPTION
Prior to this PR, it was not possible to run pyradex on molecules with collision rates for H2 + anything else (electrons, for example) because `readdata.f` assumes (incorrectly) that >2 collision partners, where one of those partners is H2, always means that the partners are pH2 and oH2.

This PR comments those lines out of readdata.f and leaves the ortho/para handling to pyradex (the python side)